### PR TITLE
fix install command in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ released under MIT license.
 Try it
 ------
 
-You can install it from nixpkgs by running ``nix-env -iA nox``.
+You can install it from nixpkgs by running ``nix-env -i nox``.
 
 To try the last version, just clone the repository, run ``nix-build``,
 and run the resulting binaries in ``result/bin``. To install it, run


### PR DESCRIPTION
The command to install nox in the readme had a -iA with only the name. I switched it to -i, but you could also switch it to -iA with the fqn
