### PR TITLE
Run `nix-env` & `nix-shell` with `--show-trace`

### DIFF
--- a/nox/nixpkgs_repo.py
+++ b/nox/nixpkgs_repo.py
@@ -77,7 +77,7 @@ def get_repo():
 
 def packages(path):
     """List all nix packages in the repo, as a set"""
-    output = subprocess.check_output(['nix-env', '-f', path, '-qaP', '--drv-path'],
+    output = subprocess.check_output(['nix-env', '-f', path, '-qaP', '--drv-path', '--show-trace'],
                                      universal_newlines=True)
     return set(output.split('\n'))
 

--- a/nox/search.py
+++ b/nox/search.py
@@ -15,7 +15,7 @@ class NixEvalError(Exception):
 def nix_packages_json():
     click.echo('Refreshing cache')
     try:
-        output = subprocess.check_output(['nix-env', '-qa', '--json'],
+        output = subprocess.check_output(['nix-env', '-qa', '--json', '--show-trace'],
                                          universal_newlines=True)
     except subprocess.CalledProcessError as e:
         raise NixEvalError from e
@@ -80,7 +80,7 @@ def main(query):
                                         value_proc=parse_input)
         attributes = [p.attribute for p in packages]
         if action == 'install':
-            subprocess.check_call(['nix-env', '-iA'] + attributes)
+            subprocess.check_call(['nix-env', '-iA', '--show-trace'] + attributes)
         elif action == 'shell':
             attributes = [a[len('nixpkgs.'):] for a in attributes]
-            subprocess.check_call(['nix-shell', '-p'] + attributes)
+            subprocess.check_call(['nix-shell', '-p', '--show-trace'] + attributes)


### PR DESCRIPTION
Evaluation is broken often enough that this seems wise.
Debugging such errors without a backtrace is most unpleasant.

Not sure how maintained this project still is, but have a PR anyway. :-) Thoughts?