### PR TITLE
Add --slug option.

### DIFF
--- a/nox/review.py
+++ b/nox/review.py
@@ -85,11 +85,12 @@ def wip(ctx, against):
 
 
 @cli.command('pr', short_help='changes in a pull request')
+@click.option('--slug', default='NixOS/nixpkgs', help='The GitHub "slug" of the repository in the from of owner_name/repo_name.')
 @click.argument('pr', type=click.INT)
 @click.pass_context
-def review_pr(ctx, pr):
+def review_pr(ctx, slug, pr):
     """Build the changes induced by the given pull request"""
-    pr_url = 'https://api.github.com/repos/NixOS/nixpkgs/pulls/{}'.format(pr)
+    pr_url = 'https://api.github.com/repos/{}/pulls/{}'.format(slug, pr)
     payload = requests.get(pr_url).json()
     click.echo('=== Reviewing PR {} : {}'.format(
                click.style(str(pr), bold=True),


### PR DESCRIPTION
The --slug option can be used to set the owner_name/repo_name format of
in nox-review of a GitHub repository. It defaults to NixOS/nixpkgs as it
behaved previously.