### PR TITLE
Add case insensitivity

### DIFF
--- a/nox/search.py
+++ b/nox/search.py
@@ -52,9 +52,10 @@ def all_packages():
 @click.argument('query', default='')
 def main(query):
     """Search a package in nix"""
+    query = query.lower()
     try:
         results = [p for p in all_packages()
-                   if any(query in s for s in p)]
+                   if any(query in s.lower() for s in p)]
     except NixEvalError:
         raise click.ClickException('An error occured while running nix (displayed above). Maybe the nixpkgs eval is broken.')
     results.sort()


### PR DESCRIPTION
I find that this improves results considerably because a lot of packages have uppercase letters but I usually don't explicitly capitalise when searching. Consider also #54.