### PR TITLE
Add case insensitivity (optional)

### DIFF
--- a/nox/search.py
+++ b/nox/search.py
@@ -50,11 +50,14 @@ def all_packages():
 
 @click.command()
 @click.argument('query', default='')
-def main(query):
+@click.option('--case-sensitive', 'case_transform', flag_value=lambda s: s)
+@click.option('--case-insensitive', 'case_transform', flag_value=lambda s: s.lower(), default=True)
+def main(query, case_transform):
     """Search a package in nix"""
+    query = case_transform(query)
     try:
         results = [p for p in all_packages()
-                   if any(query in s for s in p)]
+                   if any(query in case_transform(s) for s in p)]
     except NixEvalError:
         raise click.ClickException('An error occured while running nix (displayed above). Maybe the nixpkgs eval is broken.')
     results.sort()


### PR DESCRIPTION
I find that this improves results considerably because a lot of packages have uppercase letters but I usually don't explicitly capitalise when searching. Here the case sensitivity is optional. I'm hoping to get either this or #53 (but obviously not both) merged.