### PR TITLE
Force refresh

### DIFF
--- a/nox/cache.py
+++ b/nox/cache.py
@@ -3,6 +3,6 @@ import getpass
 
 region = make_region().configure(
     'dogpile.cache.dbm',
-    expiration_time=3600,
+    expiration_time=36000,
     arguments={'filename': '/tmp/nox.dbm.'+getpass.getuser()}
 )


### PR DESCRIPTION
This improves performance by increasing the cache lifetime while still allowing the user to force a refresh should they have updated nixpkgs in the meantime.