### PR TITLE
default.nix: Use overrideAttrs instead of overrideDerivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 with import <nixpkgs> { };
 
-stdenv.lib.overrideDerivation nox (oldAttrs : {
+nox.overrideAttrs (oldAttrs : {
   src = ./.;
   buildInputs = oldAttrs.buildInputs ++ [ git ];
 })


### PR DESCRIPTION
overrideDerivation is a worse, legacy version of overrideAttrs.