### PR TITLE
Fix --no-merge

### DIFF
--- a/nox/review.py
+++ b/nox/review.py
@@ -157,7 +157,10 @@ def review_pr(ctx, slug, token, merge, pr):
         build_sha(ctx.obj['extra-args'], attrs, merged)
 
     else:
-        attrs = differences(packages_for_sha(payload['base']['sha']),
+        commits = requests.get(payload['commits_url'], headers=headers).json()
+        base_sha = commits[-1]['parents'][0]['sha']
+
+        attrs = differences(packages_for_sha(base_sha),
                             packages_for_sha(payload['head']['sha']))
 
         build_sha(ctx.obj['extra-args'], attrs, payload['head']['sha'])


### PR DESCRIPTION
GitHub’s api reports ‘base’ as master’s HEAD. We really just want the parent of
the PR’s commits. This just requrests that directly from GitHub. If there’s a
better way, I can’t find it. This should *really* fix my issues in Nixpkgs’ travis.

If this looks good to you, after merging, can you please do another release so we can try it in Nixpkgs HEAD.