### PR TITLE
nox-review: fix `wip` click decorator

### DIFF
--- a/nox/review.py
+++ b/nox/review.py
@@ -84,7 +84,7 @@ def cli(ctx, keep_going, dry_run):
     ctx.obj['dry_run'] = dry_run
 
 
-@cli.command(short_help='difference between working tree and a commit')
+@cli.command('wip', short_help='difference between working tree and a commit')
 @click.option('--against', default='HEAD')
 @click.pass_context
 @setup_nixpkgs_config


### PR DESCRIPTION
Since f50bebb4783c60ab50875eb8383d921e2df014b7, the function the
`@cli.command` decorator sees is the one generated with
`@setup_nixpkgs_config`, i.e. `_` (c.f. nox/review.py:66). Therefore it
cannot properly guess figure the `wip` function name.

This explains the behaviour observed in
https://github.com/NixOS/nixpkgs/issues/29684:

```
$ nox-review --help
Usage: nox-review [OPTIONS] COMMAND [ARGS]...

  Review a change by building the touched commits

Options:
  -k, --keep-going  Keep going in case of failed builds
  --dry-run         Don't actually build packages, just print the
commands
                    that would have been run
  --help            Show this message and exit.

Commands:
  _   difference between working tree and a commit
  pr  changes in a pull request
```

This commit basically does what is done in nixpkgs to fix the behaviour
change:
https://github.com/NixOS/nixpkgs/commit/5f0a7cded718d0092229ba078cb7f0f7733bf636