### PR TITLE
Use single expr via stdin when invoking nix-build

### DIFF
--- a/nox/review.py
+++ b/nox/review.py
@@ -15,10 +15,9 @@ def get_build_command(args, attrs, path):
     """ Get the appropriate command to use to build the given attributes """
     command = ['nix-build']
     command += args
-    for a in attrs:
-        command.append('-A')
-        command.append(a)
-    command.append(path)
+    command.append("-E")
+
+    command.append("with import %s {}; [ %s ]" % (path, ' '.join(attrs)))
     return command
 
 

--- a/nox/tests/test_review.py
+++ b/nox/tests/test_review.py
@@ -5,8 +5,12 @@ from .. import review
 
 class TestReview(unittest.TestCase):
     def test_get_build_command(self):
-        result = review.get_build_command([], ["nox"], "./.")
-        self.assertEqual(["nix-build", "-E", "with import ./. {}; [ nox ]"], result)
+        result = review.get_build_command([])
+        self.assertEqual(["nix-build", "-E", "-"], result)
+
+    def test_get_build_expr(self):
+        result = review.get_build_expr(["nox"], "./.")
+        self.assertEqual("with import ./. {}; [ nox ]", result)
 
     def test_build_in_path(self):
         # Just do a dry run to make sure there aren't any exceptions

--- a/nox/tests/test_review.py
+++ b/nox/tests/test_review.py
@@ -5,12 +5,13 @@ from .. import review
 
 class TestReview(unittest.TestCase):
     def test_get_build_command(self):
-        result = review.get_build_command([], ["nox"], ".")
-        self.assertEqual(["nix-build", "-A", "nox", "."], result)
+        result = review.get_build_command([], ["nox"], "./.")
+        self.assertEqual(["nix-build", "-E", "with import ./. {}; [ nox ]"], result)
 
     def test_build_in_path(self):
         # Just do a dry run to make sure there aren't any exceptions
         self.assertIs(None, review.build_in_path([], ["nox"], ".", dry_run=True))
+        self.assertIs(None, review.build_in_path([], ["nox"], "./.", dry_run=True))
 
     def test_differences(self):
         # Tuples of <old set>, <new set>, <expected difference>


### PR DESCRIPTION
Handles high-impact changes significantly better (#73, #84).