### PR TITLE
nox-review: Fix --keep-going

### DIFF
--- a/nox/review.py
+++ b/nox/review.py
@@ -80,7 +80,7 @@ def cli(ctx, keep_going, dry_run):
     """Review a change by building the touched commits"""
     ctx.obj = {'extra-args': []}
     if keep_going:
-        ctx.obj['extra-args'].append(['--keep-going'])
+        ctx.obj['extra-args'].append('--keep-going')
     ctx.obj['dry_run'] = dry_run
 
 


### PR DESCRIPTION
Currently e.g. `nox-review --keep-going wip --against HEAD^` fails
because extra-args is being set to `[["--keep-going"]]`, that is a list
of list containing a string. This crashes nox later on:

````
Building in /tmp/nox-review-ig7cpfkp: clisp-tip gnu-smalltalk asymptote clisp maude ne libsigsegv urbit texlive.combined.scheme-full texlive.combined.scheme-medium tamarin-prover common-updater-scripts
Traceback (most recent call last):
  File "/nix/store/82f7gbp1byi5qp78rjrapzl7z97whjkp-nox-0.0.6/bin/.nox-review-wrapped", line 12, in <module>
    sys.exit(cli())
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/n1zl5i5wclj4rakca9bpr3gzbzw7vaf1-python3.6-click-6.7/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/nix/store/82f7gbp1byi5qp78rjrapzl7z97whjkp-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 71, in _
    f(*args, **kwargs)
  File "/nix/store/82f7gbp1byi5qp78rjrapzl7z97whjkp-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 109, in wip
    build_in_path(ctx.obj['extra-args'], attrs, '.', dry_run=ctx.obj['dry_run'])
  File "/nix/store/82f7gbp1byi5qp78rjrapzl7z97whjkp-nox-0.0.6/lib/python3.6/site-packages/nox/review.py", line 38, in build_in_path
    click.echo('Invoking {}'.format(' '.join(command)))
TypeError: sequence item 1: expected str instance, list found
````

Remove the extra list to fix the crash.