### PR TITLE
nox-review: also offer option to rebuild changed tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,4 +3,5 @@ with import <nixpkgs> { };
 nox.overrideAttrs (oldAttrs : {
   src = ./.;
   buildInputs = oldAttrs.buildInputs ++ [ git ];
+  propagatedBuildInputs = oldAttrs.propagatedBuildInputs ++ [ python3.pkgs.psutil ];
 })

--- a/nox/enumerate_tests.nix
+++ b/nox/enumerate_tests.nix
@@ -1,0 +1,36 @@
+# small utility to gather the attrname of all nixos tests
+# this is cpu intensive so instead only process 1/numJobs of the list
+{ jobIndex ? 0, numJobs ? 1, disable_blacklist ? false }:
+let
+  tests = (import <nixpkgs/nixos/release.nix> {
+    supportedSystems = [ builtins.currentSystem ];
+  }).tests;
+  lib = (import <nixpkgs/lib>);
+  blacklist = if disable_blacklist then [] else
+    # list of patterns of tests to never rebuild
+    # they depend on ./. so are rebuilt on each commit
+    [ "installer" "containers-.*" "initrd-network-ssh" "boot" "ec2-.*" ];
+  enumerate = prefix: name: value:
+  # an attr in tests is either { x86_64 = derivation; } or an attrset of such values.
+  if lib.any (x: builtins.match x name != null) blacklist then [] else
+  if lib.hasAttr builtins.currentSystem value then
+    [ {attr="${prefix}${name}"; drv = value.${builtins.currentSystem};} ]
+  else
+    lib.flatten (lib.attrValues (lib.mapAttrs (enumerate (prefix + name + ".")) value));
+  # list of {attr="tests.foo"; drv=...}
+  data = enumerate "" "tests" tests;
+  # only keep a fraction of the list
+  filterFraction = list: (lib.foldl'
+    ({n, result}: element: {
+      result = if n==jobIndex then result ++ [ element ] else result;
+      n = if n+1==numJobs then 0 else n+1;
+    })
+    { n=0; result = []; }
+    list).result;
+  myData = filterFraction data;
+  evaluable = lib.filter ({attr, drv}: (builtins.tryEval drv).success) myData;
+in
+  map ({attr, drv}: {inherit attr; drv=drv.drvPath;}) evaluable
+      
+
+

--- a/nox/nixpkgs_repo.py
+++ b/nox/nixpkgs_repo.py
@@ -1,10 +1,15 @@
 import os
 import subprocess
+import json
 from pathlib import Path
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from fnmatch import fnmatch
 
 from .cache import region
 
 import click
+import psutil
 
 
 class Repo:
@@ -22,7 +27,6 @@ class Repo:
             self.git('remote add origin https://github.com/NixOS/nixpkgs.git')
             self.git('config user.email nox@example.com')
             self.git('config user.name nox')
-
 
         if (Path.cwd() / '.git').exists():
             git_version = self.git('version', output=True).strip()
@@ -48,9 +52,6 @@ class Repo:
         f = subprocess.check_output if output else subprocess.check_call
         return f(command, *args, cwd=cwd, universal_newlines=output, **kwargs)
 
-
-
-
     def checkout(self, sha):
         self.git(['checkout', '-f', '--quiet', sha])
 
@@ -67,7 +68,9 @@ class Repo:
         except subprocess.CalledProcessError:
             return None
 
+
 _repo = None
+
 
 def get_repo():
     global _repo
@@ -76,16 +79,118 @@ def get_repo():
     return _repo
 
 
-def packages(path):
-    """List all nix packages in the repo, as a set"""
-    output = subprocess.check_output(['nix-env', '-f', path, '-qaP', '--out-path', '--show-trace'],
-                                     universal_newlines=True)
-    return set(output.split('\n'))
+class Buildable:
+    """
+    attr (str): attribute name under which the buildable can be built
+    path (str or tuple of them): for example <nixpkgs>, a list can be used to
+        pass other arguments like --argstr foo bar
+    hash: anything which contains the drvPath for example
+    __slots__ = "path", "attr", "extra_args", "hash"
+    """
+    def __init__(self, attr, hash, path="<nixpkgs>"):
+        self.attr = attr
+        self.hash = hash
+        self.path = path
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        return hash(self.hash)
+
+    @property
+    def path_args(self):
+        if isinstance(self.path, str):
+            return (self.path, )
+        return self.path
+
+    def __repr__(self):
+        return "Buildable(attr={!r}, hash={!r}, path={!r})".format(self.attr, self.hash, self.path_args)
 
 
-@region.cache_on_arguments()
-def packages_for_sha(sha):
-    """List all nix packages for the given sha"""
-    repo = get_repo()
-    repo.checkout(sha)
-    return packages(repo.path)
+def get_build_commands(buildables, program="nix-build", extra_args=[]):
+    """ Get the appropriate commands to use to build the given buildables """
+    prefix = [program]
+    prefix += extra_args
+    path_to_cmd = defaultdict(lambda *x: prefix[:])
+    for b in buildables:
+        command = path_to_cmd[b.path_args]
+        command.append('-A')
+        command.append(b.attr)
+    return [command + list(path) for path, command in path_to_cmd.items()]
+
+
+def at_given_sha(f):
+    """decorator which calls the wrappee with the path of nixpkgs at the given sha
+
+    Turns a function path -> 'a into a function sha -> 'a.
+    If the sha passed is None, passes the current directory as argument.
+    """
+    def _wrapped(sha, *args, **kwargs):
+        if sha is not None:
+            repo = get_repo()
+            repo.checkout(sha)
+            path = repo.path
+        else:
+            path = os.getcwd()
+        return f(path, *args, **kwargs)
+    _wrapped.__name__ = f.__name__
+    return _wrapped
+
+
+def cache_on_not_None(f):
+    """like region.cache_on_argument() but does not cache if the key starts None"""
+    wf = region.cache_on_arguments()(f)
+    def _wrapped(arg, *args):
+        if arg is None:
+            return f(arg, *args)
+        return wf(arg, *args)
+    _wrapped.__name__ = f.__name__
+    return _wrapped
+
+
+@cache_on_not_None
+@at_given_sha
+def packages_for_sha(path):
+    """List all nix packages in the repo, as a set of buildables"""
+    output = subprocess.check_output(['nix-env', '-f', path, '-qaP',
+        '--out-path', '--show-trace'], universal_newlines=True)
+    return {Buildable(attr, hash) for attr, hash in
+            map(lambda line: line.split(" ", 1), output.splitlines())}
+
+
+enumerate_tests = str(Path(__file__).parent / "enumerate_tests.nix")
+
+
+@cache_on_not_None
+@at_given_sha
+def tests_for_sha(path, disable_blacklist=False):
+    """List all tests wich evaluate in the repo, as a set of (attr, drvPath)"""
+    num_jobs = 32
+    # at this size, each job takes 1~1.7 GB mem
+    max_workers = max(1, psutil.virtual_memory().available//(1700*1024*1024))
+    # a job is also cpu hungry
+    try:
+        max_workers = min(max_workers, os.cpu_count())
+    except: pass
+
+    def eval(i):
+        output = subprocess.check_output(['nix-instantiate', '--eval',
+            '--json', '--strict', '-I', "nixpkgs="+str(path), enumerate_tests,
+            '--arg', "jobIndex", str(i), '--arg', 'numJobs', str(num_jobs),
+            '--arg', 'disableBlacklist', str(disable_blacklist).lower(),
+            '--show-trace'], universal_newlines=True)
+        return json.loads(output)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        evals = executor.map(eval, range(num_jobs))
+
+    path = ("<nixpkgs/nixos/release.nix>", "--arg", "supportedSystems", "[builtins.currentSystem]")
+    attrs = set()
+    for partial in evals:
+        for test in partial:
+            b = Buildable(test["attr"], test["drv"], path=path)
+            attrs.add(b)
+
+    return attrs
+

--- a/nox/tests/test_review.py
+++ b/nox/tests/test_review.py
@@ -1,23 +1,15 @@
 import unittest
 
-from .. import review
+from .. import review, nixpkgs_repo
 
 
 class TestReview(unittest.TestCase):
     def test_get_build_command(self):
-        result = review.get_build_command([], ["nox"], ".")
-        self.assertEqual(["nix-build", "-A", "nox", "."], result)
+        nox = nixpkgs_repo.Buildable("nox", hash("nox"))
+        result = review.get_build_commands([nox])
+        self.assertEqual([["nix-build", "-A", "nox", "<nixpkgs>"]], result)
 
     def test_build_in_path(self):
+        nox = nixpkgs_repo.Buildable("nox", hash("nox"))
         # Just do a dry run to make sure there aren't any exceptions
-        self.assertIs(None, review.build_in_path([], ["nox"], ".", dry_run=True))
-
-    def test_differences(self):
-        # Tuples of <old set>, <new set>, <expected difference>
-        TESTS = [
-            (set(["same"]), set(["same", "diff"]), set(["diff"])),
-            (set(["same"]), set(["same"]), set()),
-            (set(), set(["diff"]), set(["diff"]))
-        ]
-        for old, new, result in TESTS:
-            self.assertEqual(result, review.differences(old, new))
+        self.assertIs(None, review.build_sha(None, [nox], extra_args=[], dry_run=True))

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,7 @@ from setuptools import setup
 setup(
     setup_requires=['pbr'],
     pbr=True,
+    package_data={'': ['enumerate_tests.nix']},
+    include_package_data=True,
     test_suite="nox.tests"
 )


### PR DESCRIPTION
The goal was to improve discoverability of tests. Related https://github.com/NixOS/nixpkgs/pull/44439
The result is not so good. It takes more than 10 minutes to evaluate all the tests, and we have to do it twice...
Also installer tests need a copy of nixpkgs as a dependency so everytime something is changed in nixpkgs they need to be rebuilt. We need to blacklist them otherwise it will make nox-review --with-tests really unusable, but I haven't found any better solution than blacklisting by name...